### PR TITLE
Add Species Service With People Info + species homeworld

### DIFF
--- a/fullstack-challenge/API/Controllers/PeopleController.cs
+++ b/fullstack-challenge/API/Controllers/PeopleController.cs
@@ -16,7 +16,7 @@ namespace API.Controllers
         [HttpGet]
         public async Task<IActionResult> GetPeople([FromServices] IPeopleService service, [FromQuery] PeopleBindingModel query)
         {
-            var people = await service.GetPeople(query.Page);
+            var people = await service.GetAllPeople(query.Page);
             return Ok(people);
         }
     }

--- a/fullstack-challenge/API/Controllers/SpeciesController.cs
+++ b/fullstack-challenge/API/Controllers/SpeciesController.cs
@@ -1,0 +1,20 @@
+using System.Threading.Tasks;
+using API.Models;
+using Core.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace API.Controllers
+{
+    [Route("api/[controller]")]
+    [Authorize]
+    public class SpeciesController : ControllerBase
+    {
+        [HttpGet]
+        public async Task<IActionResult> GetSpecies([FromServices] ISpeciesService service, [FromQuery] SpeciesBindingModel model)
+        {
+            var species = await service.GetAllSpecies(model.page);
+            return Ok(species);
+        }
+    }
+}

--- a/fullstack-challenge/API/Models/AccessTokenBindingModel.cs
+++ b/fullstack-challenge/API/Models/AccessTokenBindingModel.cs
@@ -1,9 +1,0 @@
-namespace API.Models
-{
-    public class AccessTokenBindingModel
-    {
-        public string ClientId { get; set; }
-        public string ClientSecret { get; set; }
-        public string Scope { get; set; }
-    }
-}

--- a/fullstack-challenge/API/Models/SpeciesBindingModel.cs
+++ b/fullstack-challenge/API/Models/SpeciesBindingModel.cs
@@ -1,0 +1,7 @@
+namespace API.Models
+{
+    public class SpeciesBindingModel
+    {
+        public int page { get; set; }
+    }
+}

--- a/fullstack-challenge/API/Startup.cs
+++ b/fullstack-challenge/API/Startup.cs
@@ -15,6 +15,7 @@ using AutoMapper;
 using Core.Entities;
 using Core.Interfaces;
 using Core.Services.Models;
+using Core.AutoMapper;
 
 namespace API
 {
@@ -42,7 +43,7 @@ namespace API
                         });
 
             ConfigureDependencyInjection(services);
-            ConfigureAutoMapper();
+            ConfigureAutoMapper(services);
         }
 
         private void ConfigureDependencyInjection(IServiceCollection services){
@@ -51,8 +52,9 @@ namespace API
             services.AddTransient<ISpeciesService, SpeciesService>();
         }
 
-        private void ConfigureAutoMapper(){
-            Mapper.Initialize(cfg => cfg.CreateMap<SwapiPerson, Person>());
+        private void ConfigureAutoMapper(IServiceCollection services){
+            var mapper = AutoMapperConfiguration.Configure();
+            services.AddSingleton(mapper);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/fullstack-challenge/Core/AutoMapper/AutoMapperConfiguration.cs
+++ b/fullstack-challenge/Core/AutoMapper/AutoMapperConfiguration.cs
@@ -1,0 +1,22 @@
+using AutoMapper;
+using Core.Entities;
+using Core.Services.Models;
+
+namespace Core.AutoMapper
+{
+    public static class AutoMapperConfiguration
+    {
+        public static IMapper Configure()
+        {
+            var config = new MapperConfiguration(cfg =>
+            {
+                cfg.CreateMap<SwapiSpecies, Species>();
+                cfg.CreateMap<SwapiPerson, Person>();
+            });
+
+            var mapper = config.CreateMapper();
+            return mapper;
+        }
+
+    }
+}

--- a/fullstack-challenge/Core/Entities/Person.cs
+++ b/fullstack-challenge/Core/Entities/Person.cs
@@ -1,14 +1,14 @@
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 
-namespace Core.Entities{
+namespace Core.Entities
+{
     [DataContract]
-    public class Person{
+    public class Person
+    {
         [DataMember]
         public string Name { get; set; }
         [DataMember]
         public string Homeworld { get; set; }
-        [DataMember]
-        public List<string> Species { get; set; }
     }
 }

--- a/fullstack-challenge/Core/Entities/Species.cs
+++ b/fullstack-challenge/Core/Entities/Species.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace Core.Entities
+{
+    public class Species
+    {
+        public string Name { get; set; }
+        public string Homeworld { get; set; }
+        public List<Person> Persons { get; set; }
+    }
+}

--- a/fullstack-challenge/Core/Interfaces/IPeopleService.cs
+++ b/fullstack-challenge/Core/Interfaces/IPeopleService.cs
@@ -1,10 +1,12 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Core.Entities;
+using Core.Services.Models;
 
 namespace Core.Interfaces{
     public interface IPeopleService
     {
-        Task<List<Person>> GetPeople(int pageNumber);
+        Task<List<Person>> GetAllPeople(int pageNumber);
+        Task<SwapiPerson> GetPersonByUrl(string personUrl);
     }
 }

--- a/fullstack-challenge/Core/Interfaces/ISpeciesService.cs
+++ b/fullstack-challenge/Core/Interfaces/ISpeciesService.cs
@@ -1,10 +1,13 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
+using Core.Entities;
 using Core.Services.Models;
 
 namespace Core.Interfaces
 {
     public interface ISpeciesService
     {
-        Task<SwapiSpecies> GetSpecies(string speciesUrl);
+        Task<SwapiSpecies> GetSpeciesByUrl(string speciesUrl);
+        Task<List<Species>> GetAllSpecies(int pageNumber);
     }
 }

--- a/fullstack-challenge/Core/Services/Models/SwapiSpecies.cs
+++ b/fullstack-challenge/Core/Services/Models/SwapiSpecies.cs
@@ -20,4 +20,12 @@ namespace Core.Services.Models
         public string edited { get; set; }
         public string url { get; set; }
     }
+
+    public class SwapiSpeciesResponse
+    {
+        public int count { get; set; }
+        public string next { get; set; }
+        public object previous { get; set; }
+        public List<SwapiSpecies> results { get; set; }
+    }
 }

--- a/fullstack-challenge/Core/Services/PlanetService.cs
+++ b/fullstack-challenge/Core/Services/PlanetService.cs
@@ -22,8 +22,8 @@ namespace Core.Services
 
         private async Task<string> GetPlanetFromSwapi(string planetUrl)
         {
-            var response = await client.GetAsync(planetUrl);
-            return await response.Content.ReadAsStringAsync();
+            var response = await client.GetStringAsync(planetUrl);
+            return response;
         }
     }
 }

--- a/fullstack-challenge/Core/Services/SpeciesService.cs
+++ b/fullstack-challenge/Core/Services/SpeciesService.cs
@@ -1,8 +1,12 @@
+using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
 using System.Runtime.Serialization.Json;
 using System.Text;
 using System.Threading.Tasks;
+using AutoMapper;
+using Core.Entities;
 using Core.Interfaces;
 using Core.Services.Models;
 using Newtonsoft.Json;
@@ -11,19 +15,77 @@ namespace Core.Services
 {
     public class SpeciesService : ISpeciesService
     {
-        private static readonly HttpClient client = new HttpClient();
 
-        public async Task<SwapiSpecies> GetSpecies(string speciesUrl)
+        string swapiUrl = "https://swapi.co/api/";
+        private static readonly HttpClient client = new HttpClient();
+        private IPeopleService peopleService;
+        private readonly IPlanetService planetService;
+        private IMapper mapper;
+
+        public SpeciesService(IPeopleService peopleService, IPlanetService planetService, IMapper mapper)
         {
-            var jsonResponse = await GetSpeciesFromSwapi(speciesUrl);
-            var swapiSpecies = JsonConvert.DeserializeObject<SwapiSpecies>(jsonResponse);
+            this.peopleService = peopleService;
+            this.planetService = planetService;
+            this.mapper = mapper;
+        }
+
+        public async Task<SwapiSpecies> GetSpeciesByUrl(string speciesUrl)
+        {
+            var response = await client.GetStringAsync(speciesUrl);
+            var swapiSpecies = JsonConvert.DeserializeObject<SwapiSpecies>(response);
             return swapiSpecies;
         }
 
-        private async Task<string> GetSpeciesFromSwapi(string speciesUrl)
+        public async Task<List<Species>> GetAllSpecies(int pageNumber)
         {
-            var response = await client.GetAsync(speciesUrl);
-            return await response.Content.ReadAsStringAsync();
+            var swapiSpeciesResponse = await GetAllSpeciesFromSwapi(pageNumber);
+            var speciesList = new List<Species>();
+            foreach (var swapiSpecies in swapiSpeciesResponse.results)
+            {
+                var species = await GetSpeciesFullInfo(swapiSpecies);
+                speciesList.Add(species);
+            }
+            return speciesList;
+        }
+
+        private async Task<SwapiSpeciesResponse> GetAllSpeciesFromSwapi(int pageNumber)
+        {
+            string requestUrl = $"{swapiUrl}species/?page={pageNumber}";
+            if (pageNumber == 0)
+            {
+                requestUrl = $"{swapiUrl}species/";
+            }
+            var response = await client.GetStringAsync(requestUrl);
+
+            var swapiSpeciesResponse = JsonConvert.DeserializeObject<SwapiSpeciesResponse>(response);
+            return swapiSpeciesResponse;
+        }
+
+        private async Task<Species> GetSpeciesFullInfo(SwapiSpecies swapiSpecies)
+        {
+            var species = mapper.Map<SwapiSpecies, Species>(swapiSpecies);
+            species.Persons = new List<Person>();
+            species.Homeworld = await GetPlanetName(swapiSpecies.homeworld);
+            foreach (var personUrl in swapiSpecies.people)
+            {
+                var person = await GetPersonFullInfo(personUrl);
+                species.Persons.Add(person);
+            }
+            return species;
+        }
+
+        private async Task<Person> GetPersonFullInfo(string personUrl)
+        {
+            var swapiPerson = await peopleService.GetPersonByUrl(personUrl);
+            var person = mapper.Map<SwapiPerson, Person>(swapiPerson);
+            person.Homeworld = await GetPlanetName(swapiPerson.homeworld);
+            return person;
+        }
+
+        private async Task<string> GetPlanetName(string planetUrl)
+        {
+            var swapiPlanet = await planetService.GetPlanet(planetUrl);
+            return swapiPlanet.name;
         }
     }
 }


### PR DESCRIPTION
Added AutoMapper Configuration Class to use it with DI instead of the static mapping method approach
Removed Species Info retrieval from PeopleService
Removed unused class AccessTokenBindingModel
Added Species Entity
Added Species Service that retrieves all species with people objects and species homeworld
Added SwapiSpeciesResponse json mapping class
Removed list of species from People Entity
Refactoring of code, e.g. changed GetAsync methods to GetString Async, indentation fixes and refactoring of big methods to smaller ones with meaningfull names